### PR TITLE
chore: remove unused service and update env template

### DIFF
--- a/docker-compose/.env.example
+++ b/docker-compose/.env.example
@@ -63,7 +63,7 @@ DEVICE_ENDPOINT_HOST=
 # - Leave empty to disable domain restriction (allow access via any domain)
 WEB_UI_HOST=
 
-GLKVM access IP seen by devices/users.
+#GLKVM access IP seen by devices/users.
 # Leave empty to auto-detect at container start.
 GLKVM_ACCESS_IP=
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.0"
-
 services:
   rttys:
     image: ${GLKVM_IMAGE:-glzhitong/glkvm-cloud:latest}


### PR DESCRIPTION
- Commented out the deprecated configuration line in `docker-compose/.env.example`
- Removed the associated service from Docker Compose files as it is no longer required